### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -303,7 +303,7 @@ class Luno {
    */
   getTradesList (since, limit, pair) {
     if (since && since instanceof Date) {
-      since = since.getTime() / 1000 // Convert to unix timestamp
+      since = since.getTime() // Convert to unix timestamp
     }
 
     pair = pair || this.defaultPair


### PR DESCRIPTION
Don't / 1000 on date -> millis convert. Divide by 1000 is returning an invalid date milliseconds, so we end up getting all trades since 1970